### PR TITLE
docs: provide example of provide

### DIFF
--- a/docs/en/class-component/injection/code-usage.ts
+++ b/docs/en/class-component/injection/code-usage.ts
@@ -15,3 +15,16 @@ export default class MyComponent extends Vue {
     @Inject
     readonly name!: string
 }
+
+// Example of `provide` usage in any parent component
+
+@Component({
+  provide(this: MyParentComponent){
+    return {
+      name: computed(() => this.name),
+    }
+  }
+})
+export default class MyParentComponent extends Vue {
+    name: string
+}


### PR DESCRIPTION
The existing documentation makes it difficult to set up `provide` with correct types using a class-based component. Because [`@Provide`](https://github.com/kaorun343/vue-property-decorator#Provide) isn't supported anymore, there is also no direct migration step available. This example uses `this` to provide a type of the parent component, and it also shows how to make this property reactive using `computed` (implicitly imported from `@vue/reactivity`), which serves as a replacement of [`@ProvideReactive`](https://github.com/kaorun343/vue-property-decorator#ProvideReactive) + [`@InjectReactive`](https://github.com/kaorun343/vue-property-decorator#ProvideReactive).

🗒️ Below version Vue 3.3, `unwrapInjectedRef` configuration is supposed to be used as a workaround to support using `computed` without using ref on the inject side (otherwise it's notified as a console warning); here is a Nuxt 3 example for `app.vue`:
```vue
<script setup lang="ts">
// TODO: remove once this is default in Vue 3.3
useNuxtApp().vueApp.config.unwrapInjectedRef = true
</script>
```