### PR TITLE
✅ Reduce test log noise

### DIFF
--- a/test/feature/hooks.ts
+++ b/test/feature/hooks.ts
@@ -15,7 +15,7 @@ class Comp extends Base {
 
 }
 const CompContext = toNative(Comp) as any
-console.log('hhh',CompContext)
+
 describe('feature hooks',
     () => {
         it('default', () => {

--- a/test/option/accessor.ts
+++ b/test/option/accessor.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import 'mocha';
 import { Component, Base, Vanilla, toNative } from '../../dist'
 
-@Component
+@Component({template: '<div/>'})
 class Comp extends Base {
 
     @Vanilla

--- a/test/option/data.ts
+++ b/test/option/data.ts
@@ -4,7 +4,7 @@ import 'mocha';
 import { Component, Base, Prop, toNative } from '../../dist'
 import { mount } from '@vue/test-utils'
 
-@Component
+@Component({template: '<div/>'})
 class Comp extends Base {
 
     data = 'data value'


### PR DESCRIPTION
 - Remove `console.log()`
 - Set missing templates to resolve a warning:

```
[Vue warn]: Component is missing template or render function.
```