### PR TITLE
🐛 Fix reactivity for `@Provide`

### DIFF
--- a/src/option/provide.ts
+++ b/src/option/provide.ts
@@ -1,3 +1,4 @@
+import { computed } from 'vue';
 import type { Cons } from '../component';
 import type { OptionBuilder } from '../optionBuilder'
 import { obtainSlot, optionNullableMemberDecorator } from '../utils'
@@ -12,12 +13,11 @@ export const decorator = optionNullableMemberDecorator(function (proto: any, nam
 
 export function build(cons: Cons, optionBuilder: OptionBuilder, vueInstance: any) {
     optionBuilder.provide ??= {}
-    const sample = new cons(optionBuilder, vueInstance) as any
     const slot = obtainSlot(cons.prototype)
     const names = slot.obtainMap('provide')
     if (!names) return null
     names.forEach((value, name) => {
         const key = value === null ? name : value
-        optionBuilder.provide![key] = sample[name]
+        optionBuilder.provide![key] = computed(() => vueInstance[name])
     })
 }


### PR DESCRIPTION
Fixes https://github.com/facing-dev/vue-facing-decorator/issues/80

This change fixes reactivity when using Provide/Inject. This previously didn't work, because we froze the provided value at `provide()` invocation time by just accessing `sample[name]`.

This change automagically wraps any provided values in a `computed()` wrapper, which should update downstream injected values whenever the provider changes.

This does two things of note:

 1. It uses the Vue.js `computed()` function as demonstrated in the [docs][1]
 2. It wraps *any* provided value in `computed()`, including `data`, which removes the need for the extra getter demonstrated in the docs, but is a departure from the "standard" Vue component Options API

Note that to use this now requires setting `unwrapInjectedRef: true`.

[1]: https://vuejs.org/guide/components/provide-inject.html#working-with-reactivity