### PR TITLE
🐛 Avoid emitting `undefined` as a return value

### DIFF
--- a/src/option/emit.ts
+++ b/src/option/emit.ts
@@ -28,7 +28,9 @@ export function build(cons: Cons, optionBuilder: OptionBuilder) {
                 const proRet = await ret
                 this.$emit(eventName, proRet)
             }
-            else {
+            else if (ret === undefined) {
+                this.$emit(eventName)
+            } else {
                 this.$emit(eventName, ret)
             }
         }

--- a/test/option/emit.ts
+++ b/test/option/emit.ts
@@ -2,6 +2,7 @@
 import { expect } from 'chai';
 import 'mocha';
 import { Component, Emit, Base, toNative } from '../../dist'
+import {mount} from '@vue/test-utils';
 
 @Component
 class Comp extends Base {
@@ -24,6 +25,9 @@ class Comp extends Base {
 
         })
     }
+
+    @Emit
+    noReturn() {}
 
 }
 const CompContext = toNative(Comp) as any
@@ -72,6 +76,11 @@ describe('decorator Emit',
             })
             expect(emitName).to.equal('promiseEmit')
             expect(emitValue).to.equal('promiseEmit value')
+        })
+        it('has an empty array when emitting void', () => {
+            const component = mount(CompContext)
+            component.vm.noReturn()
+            expect(component.emitted('noReturn')).to.eql([[]])
         })
     }
 )


### PR DESCRIPTION
Consider an empty emitter function:

```ts
@Component
class MyComponent {
  @Emit
  public foo(): void {}
}
```

We would expect this to emit a `'foo'` event with no arguments (since the return value is `undefined`).

However, when testing with `@vue/test-utils`, we have to write:

```ts
expect(component.emitted('foo')).to.eql([[undefined]])
```

But it would be nicer - and more consistent with [`vue-property-decorator`][1] - if we instead called `$emit()` with no arguments in this case to be able to write:

```ts
expect(component.emitted('foo')).to.eql([[]])
```

[1]: https://github.com/kaorun343/vue-property-decorator/blob/e04872349bab357e6d08b01442f83abc9976eb50/src/decorators/Emit.ts#L22