### PR TITLE
Prevent circular import, fix build in Vite 6

### DIFF
--- a/src/mixins.ts
+++ b/src/mixins.ts
@@ -1,7 +1,7 @@
 import { ComponentBase } from './component'
 import { obtainSlot } from './slot'
 import type { VueCons } from './class'
-import { Vue } from './index'
+import { Base as Vue } from './class'
 
 import type { MergeIdentityType, IdentitySymbol } from './identity'
 type MixedClass<Mixins extends VueCons[], Base extends VueCons = VueCons> =


### PR DESCRIPTION
Fix #146.

To be honest I'd drop `Base` export altogether and cleanup the related internal imports (I think `Base` is not documented and there's no point in this name), but I decided to keep this hotfix commit as short as possible.